### PR TITLE
Composer support for PHP_Timer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "pear/PHP_Timer",
+    "name": "sebastianbergmann/php-timer",
     "description": "Utility class for timing",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Sebastian Bergmann",
@@ -12,6 +12,6 @@
         "php": ">=5.2.7"
     },
     "autoload": {
-        "psr-0": { "PHP_Timer": "" }
+        "classmap": ["PHP/Timer.php"]
     }
 }


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a dependency management system for PHP packages. This pull request adds Composer support to PHP Timer. Having this means that a project can use something like the following in a composer.json to depict a dependency on PHP_Timer:

```
"require": {
    "sebastianbergmann/php-timer": "*"
}
```
