### PR TITLE
Fixes #7

### DIFF
--- a/PHP/Timer.php
+++ b/PHP/Timer.php
@@ -109,27 +109,32 @@ class PHP_Timer
     {
         $buffer = '';
 
+        $time    = floor($time * 1000.0) / 1000.0;
         $hours   = sprintf('%02d', ($time >= 3600) ? floor($time / 3600) : 0);
         $minutes = sprintf(
                      '%02d',
                      ($time >= 60)   ? floor($time /   60) - 60 * $hours : 0
                    );
-        $seconds = sprintf('%02d', $time - 60 * 60 * $hours - 60 * $minutes);
+        $seconds = sprintf('%06.3F', $time - 60 * 60 * $hours - 60 * $minutes);
 
         if ($hours == 0 && $minutes == 0) {
-            $seconds = sprintf('%1d', $seconds);
+            if ($seconds < 1) {
+                $buffer = ($seconds * 1000) . ' ms';
+            } else {
+                $seconds = (float)$seconds;
 
-            $buffer .= $seconds . ' second';
+                $buffer .= $seconds . ' second';
 
-            if ($seconds != '1') {
-                $buffer .= 's';
+                if ($seconds != '1') {
+                    $buffer .= 's';
+                }
             }
         } else {
             if ($hours > 0) {
                 $buffer = $hours . ':';
             }
 
-            $buffer .= $minutes . ':' . $seconds;
+            $buffer .= $minutes . ':' . str_replace('.', ':', $seconds);
         }
 
         return $buffer;

--- a/Tests/TimerTest.php
+++ b/Tests/TimerTest.php
@@ -80,15 +80,40 @@ class PHP_TimerTest extends PHPUnit_Framework_TestCase
      */
     public function testSecondsToTimeString()
     {
-        $this->assertEquals('0 seconds', $this->timer->secondsToTimeString(0));
+        $this->assertEquals('0 ms', $this->timer->secondsToTimeString(0));
+        $this->assertEquals('1 ms', $this->timer->secondsToTimeString(.001));
+        $this->assertEquals('10 ms', $this->timer->secondsToTimeString(.01));
+        $this->assertEquals('100 ms', $this->timer->secondsToTimeString(.1));
+        $this->assertEquals('999 ms', $this->timer->secondsToTimeString(.999));
+        $this->assertEquals('999 ms', $this->timer->secondsToTimeString(.9999));
         $this->assertEquals('1 second', $this->timer->secondsToTimeString(1));
         $this->assertEquals('2 seconds', $this->timer->secondsToTimeString(2));
-        $this->assertEquals('01:00', $this->timer->secondsToTimeString(60));
-        $this->assertEquals('01:01', $this->timer->secondsToTimeString(61));
-        $this->assertEquals('02:00', $this->timer->secondsToTimeString(120));
-        $this->assertEquals('02:01', $this->timer->secondsToTimeString(121));
-        $this->assertEquals('01:00:00', $this->timer->secondsToTimeString(3600));
-        $this->assertEquals('01:00:01', $this->timer->secondsToTimeString(3601));
+        $this->assertEquals('59.9 seconds', $this->timer->secondsToTimeString(59.9));
+        $this->assertEquals('59.99 seconds', $this->timer->secondsToTimeString(59.99));
+        $this->assertEquals('59.999 seconds', $this->timer->secondsToTimeString(59.999));
+        $this->assertEquals('59.999 seconds', $this->timer->secondsToTimeString(59.9999));
+        $this->assertEquals('59.001 seconds', $this->timer->secondsToTimeString(59.001));
+        $this->assertEquals('59.01 seconds', $this->timer->secondsToTimeString(59.01));
+        $this->assertEquals('01:00:000', $this->timer->secondsToTimeString(60));
+        $this->assertEquals('01:01:000', $this->timer->secondsToTimeString(61));
+        $this->assertEquals('02:00:000', $this->timer->secondsToTimeString(120));
+        $this->assertEquals('02:01:000', $this->timer->secondsToTimeString(121));
+        $this->assertEquals('59:59:900', $this->timer->secondsToTimeString(3599.9));
+        $this->assertEquals('59:59:990', $this->timer->secondsToTimeString(3599.99));
+        $this->assertEquals('59:59:999', $this->timer->secondsToTimeString(3599.999));
+        $this->assertEquals('59:59:999', $this->timer->secondsToTimeString(3599.9999));
+        $this->assertEquals('59:59:001', $this->timer->secondsToTimeString(3599.001));
+        $this->assertEquals('59:59:010', $this->timer->secondsToTimeString(3599.01));
+        $this->assertEquals('01:00:00:000', $this->timer->secondsToTimeString(3600));
+        $this->assertEquals('01:00:01:000', $this->timer->secondsToTimeString(3601));
+        $this->assertEquals('01:00:01:900', $this->timer->secondsToTimeString(3601.9));
+        $this->assertEquals('01:00:01:990', $this->timer->secondsToTimeString(3601.99));
+        $this->assertEquals('01:00:01:999', $this->timer->secondsToTimeString(3601.999));
+        $this->assertEquals('01:00:01:999', $this->timer->secondsToTimeString(3601.9999));
+        $this->assertEquals('01:00:59:999', $this->timer->secondsToTimeString(3659.9999));
+        $this->assertEquals('01:00:59:001', $this->timer->secondsToTimeString(3659.001));
+        $this->assertEquals('01:00:59:010', $this->timer->secondsToTimeString(3659.01));
+        $this->assertEquals('01:59:59:999', $this->timer->secondsToTimeString(7199.9999));
     }
 
     /**
@@ -97,7 +122,7 @@ class PHP_TimerTest extends PHPUnit_Framework_TestCase
     public function testTimeSinceStartOfRequest()
     {
         $this->assertStringMatchesFormat(
-          '%i %s', $this->timer->timeSinceStartOfRequest()
+          '%f %s', $this->timer->timeSinceStartOfRequest()
         );
     }
 


### PR DESCRIPTION
Added milliseconds to the string returned by `secondsToTimeString()`.
