### PR TITLE
fix for 32-bit where large value are converted to float

### DIFF
--- a/src/Timer.php
+++ b/src/Timer.php
@@ -44,7 +44,7 @@ final class Timer
         return \microtime(true) - \array_pop(self::$startTimes);
     }
 
-    public static function bytesToString(int $bytes): string
+    public static function bytesToString(float $bytes): string
     {
         foreach (self::$sizes as $unit => $value) {
             if ($bytes >= $value) {
@@ -54,7 +54,7 @@ final class Timer
             }
         }
 
-        return $bytes . ' byte' . ($bytes !== 1 ? 's' : '');
+        return $bytes . ' byte' . ((int)$bytes !== 1 ? 's' : '');
     }
 
     public static function secondsToTimeString(float $time): string

--- a/src/Timer.php
+++ b/src/Timer.php
@@ -48,9 +48,7 @@ final class Timer
     {
         foreach (self::$sizes as $unit => $value) {
             if ($bytes >= $value) {
-                $size = \sprintf('%.2f', $bytes >= 1024 ? $bytes / $value : $bytes);
-
-                return $size . ' ' . $unit;
+                return \sprintf('%.2f %s', $bytes >= 1024 ? $bytes / $value : $bytes, $unit);
             }
         }
 

--- a/tests/TimerTest.php
+++ b/tests/TimerTest.php
@@ -112,7 +112,7 @@ final class TimerTest extends TestCase
     /**
      * @dataProvider bytesProvider
      */
-    public function testCanFormatBytesAsString(string $string, int $bytes): void
+    public function testCanFormatBytesAsString(string $string, float $bytes): void
     {
         $this->assertEquals($string, Timer::bytesToString($bytes));
     }


### PR DESCRIPTION
Test suite fails on 32-bit computer (yes, this still exists.... arm...)

```
There were 2 errors:
1) SebastianBergmann\Timer\TimerTest::testCanFormatBytesAsString with data set #7 ('3.00 GB', 3221225472.0)
TypeError: Argument 2 passed to SebastianBergmann\Timer\TimerTest::testCanFormatBytesAsString() must be of the type integer, float given, called in /usr/share/php/PHPUnit7/Framework/TestCase.php on line 1153
/builddir/build/BUILD/php-timer-8b389aebe1b8b0578430bda0c7c95a829608e059/tests/TimerTest.php:115
2) SebastianBergmann\Timer\TimerTest::testCanFormatBytesAsString with data set #8 ('3.50 GB', 3758096384.0)
TypeError: Argument 2 passed to SebastianBergmann\Timer\TimerTest::testCanFormatBytesAsString() must be of the type integer, float given, called in /usr/share/php/PHPUnit7/Framework/TestCase.php on line 1153
/builddir/build/BUILD/php-timer-8b389aebe1b8b0578430bda0c7c95a829608e059/tests/TimerTest.php:115
```

Allowing float (large integer) seems to  me the simple way (despite I really think memory consumption should never be so high on a 32-bit computer... but some still running 32-bit software on big hardware for strange reasons...)