### PR TITLE
Nano optimization when acquiring time

### DIFF
--- a/src/Timer.php
+++ b/src/Timer.php
@@ -21,7 +21,7 @@ final class Timer
 
     public function start(): void
     {
-        $this->startTimes[] = (float) hrtime(true);
+        $this->startTimes[] = hrtime(true);
     }
 
     /**
@@ -29,12 +29,14 @@ final class Timer
      */
     public function stop(): Duration
     {
+        $current = hrtime(true);
+
         if (empty($this->startTimes)) {
             throw new NoActiveTimerException(
                 'Timer::start() has to be called before Timer::stop()'
             );
         }
 
-        return Duration::fromNanoseconds((float) hrtime(true) - array_pop($this->startTimes));
+        return Duration::fromNanoseconds((float) $current - (float) array_pop($this->startTimes));
     }
 }


### PR DESCRIPTION
Hi,

I'm building for fun a [small library](https://github.com/loophp/nanobench) for benchmarking Closures and I started it by doing my own Stopwatch class.
Then, by chance I found this package and I decided to use it as hard dependency instead.

This PR:

* [x] Move the `hrtime()` call at the beginning of the `stop()` method, for a better accuracy. Indeed, executing the `if` condition takes time and this will prevent that loss of time.
* [x] Do not cast `hrtime()` before saving it in `$this->startTimes`. Once again, casting the value will take time, so, we can do it at the very end in order to prevent that loss of time due to the casting.
* [x] This is not even micro optimization, this is nano optimization! :-)
