### PR TITLE
Implement interfaces for Timer and Duration

### DIFF
--- a/src/Duration.php
+++ b/src/Duration.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 /*
  * This file is part of phpunit/php-timer.
  *
@@ -15,7 +16,7 @@ use function sprintf;
 /**
  * @psalm-immutable
  */
-final class Duration
+final class Duration implements DurationInterface
 {
     /**
      * @var float

--- a/src/DurationInterface.php
+++ b/src/DurationInterface.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of phpunit/php-timer.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Timer;
+
+interface DurationInterface
+{
+    public function asNanoseconds(): float;
+
+    public function asMicroseconds(): float;
+
+    public function asMilliseconds(): float;
+
+    public function asSeconds(): float;
+
+    public function asString(): string;
+}

--- a/src/Timer.php
+++ b/src/Timer.php
@@ -12,7 +12,7 @@ namespace SebastianBergmann\Timer;
 use function array_pop;
 use function hrtime;
 
-final class Timer
+final class Timer implements TimerInterface
 {
     /**
      * @psalm-var list<float>
@@ -24,9 +24,6 @@ final class Timer
         $this->startTimes[] = (float) hrtime(true);
     }
 
-    /**
-     * @throws NoActiveTimerException
-     */
     public function stop(): Duration
     {
         if (empty($this->startTimes)) {

--- a/src/TimerInterface.php
+++ b/src/TimerInterface.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of phpunit/php-timer.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Timer;
+
+interface TimerInterface
+{
+    public function start(): void;
+
+    /**
+     * @throws NoActiveTimerException
+     */
+    public function stop(): Duration;
+}


### PR DESCRIPTION
This commit pulls function signatures and DocBlocks into interfaces so downstream consumers are able to mock Timer and Duration in unit tests.